### PR TITLE
Make live-py-mode.el ready for MELPA

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -1,10 +1,35 @@
+;;; live-py-mode.el --- Live Coding in Python
+
+;; Copyright (C) 2015 Don Kirkby, Antti Kaihola
+
+;; Author: Antti Kaihola <akaihol+github@ambitone.com>
+;; Keywords: live coding
+;; URL: https://github.com/donkirkby/live-py-plugin
+;; Version: 2015
+;; X-Original-Version: 0.1
+;; Package-Requires: ((emacs "24.1"))
+
+;; This program is distributed under the Eclipse Public License - v 1.0
+;; For more information see https://www.eclipse.org/legal/epl-v10.html
+
+;;; Commentary:
+
+;; To use it, put the following in your Emacs configuration file:
+;;
+;;   (require 'live-py-mode)
+;;   Open a Python file and run M-x live-py-mode
+;;
+;; Requirements: Emacs 24.
+
+;;; Code:
 (defun live-py-after-change-function (start stop len)
-  "Run the buffer through the code tracer and show results in the trace buffer"
+  "Run the buffer through the code tracer and show results in the trace buffer."
   (when live-py-timer (cancel-timer live-py-timer))
   (set 'live-py-timer (run-at-time 0.5 nil 'live-py-trace)))
 
 
 (defun live-py-trace ()
+  "Trace the Python code using code_tracer.py."
   (let* ((tracer-path (locate-file "code_tracer.py" load-path))
          (buffer-dir (file-name-directory (buffer-file-name)))
          (command-line (concat "python " tracer-path))
@@ -22,6 +47,7 @@
 
 
 (defun live-py-synchronize-scroll ()
+  "Synchronise scrolling between Python and live-py buffers."
   (let ((code-window-start (+ (count-lines 1 (window-start)) 1))
         (position (line-number-at-pos)))
     (unless (window-valid-p live-py-output-window)
@@ -46,6 +72,7 @@
 
 
 (defun live-py-show-output-window ()
+  "Show the live-py output window."
   (delete-other-windows)
   (get-buffer-create live-py-output-buffer)
   (with-current-buffer live-py-output-buffer
@@ -90,3 +117,5 @@ With arg, turn mode on if and only if arg is positive."
   )
 
 (provide 'live-py-mode)
+
+;;; live-py-mode.el ends here


### PR DESCRIPTION
Some changes to the emacs mode for compability with packaging.

Please check the copyright and email.

I've used the email I found on the github page of @akaihola but maybe we should yours since it is in your repository?

Related to https://github.com/donkirkby/live-py-plugin/issues/50