### PR TITLE
Buffer local variable should be declared as global variable

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -22,6 +22,11 @@
 ;; Requirements: Emacs 24.
 
 ;;; Code:
+
+(defvar live-py-timer)
+(defvar live-py-output-buffer)
+(defvar live-py-output-window)
+
 (defun live-py-after-change-function (start stop len)
   "Run the buffer through the code tracer and show results in the trace buffer."
   (when live-py-timer (cancel-timer live-py-timer))


### PR DESCRIPTION
This caused byte-compile warning.

```
In live-py-after-change-function:                                                 
live-py-mode.el:27:9:Warning: reference to free variable `live-py-timer'          
live-py-mode.el:28:9:Warning: assignment to free variable `live-py-timer'         
                                                                                  
In live-py-trace:                                                                 
live-py-mode.el:42:30:Warning: reference to free variable                         
    `live-py-output-buffer'                                                       
live-py-mode.el:46:9:Warning: assignment to free variable `live-py-timer'         
                                                                                  
In live-py-synchronize-scroll:                                                    
live-py-mode.el:53:29:Warning: reference to free variable                         
    `live-py-output-window'
```