### PR TITLE
Add autoload cookie for the minor mode

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -87,6 +87,7 @@
   (set-window-buffer live-py-output-window live-py-output-buffer))
 
 
+;;;###autoload
 (define-minor-mode live-py-mode
   "Minor mode to do on-the-fly Python tracing.
 When called interactively, toggles the minor mode.


### PR DESCRIPTION
This allows the user to enable the mode without having explicitly required the file first.