### PR TITLE
Dont display trailing whitespace

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -83,7 +83,8 @@
   (with-current-buffer live-py-output-buffer
     (toggle-truncate-lines 1))
   (set (make-local-variable 'live-py-output-window)
-       (split-window-horizontally))
+       (split-window-horizontally)
+       (setq show-trailing-whitespace nil))
   (set-window-buffer live-py-output-window live-py-output-buffer))
 
 


### PR DESCRIPTION
Dont display trailing whitespace in live-py-output-window