### PR TITLE
Show delaying and tracing in Emacs mode line

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -41,11 +41,18 @@
   "After a delay run the buffer through the code tracer and show trace.
 START, STOP and LEN are required by `after-change-functions' but unused."
   (ignore start stop len)
-  (when live-py-timer (cancel-timer live-py-timer))
+  (if live-py-timer
+      (cancel-timer live-py-timer)
+    (setq-local live-py-lighter " Live-D") ; D for delaying
+    ;; Here it seems not necessary to `force-mode-line-update'.
+    (redisplay))
   (setq-local live-py-timer (run-at-time 0.5 nil 'live-py-trace-update)))
 
 (defun live-py-trace-update ()
   "Trace the Python code using code_tracer.py."
+  (setq-local live-py-lighter " Live-T") ; T for tracing
+  (force-mode-line-update)
+  (redisplay)
   (let* ((tracer-path (locate-file "code_tracer.py" load-path))
          (command-line-start (concat
 			      (shell-quote-argument live-py-version)
@@ -78,8 +85,8 @@ START, STOP and LEN are required by `after-change-functions' but unused."
                                           (1+ (buffer-size))
                                           command-line
                                           live-py-trace-buffer))
-           " live"
-         " live(FAIL)")))
+           " Live-t" ; t for trace ready
+         " Live-FAIL")))
     (with-current-buffer live-py-trace-buffer
       (setq-local buffer-read-only 1)
       (unless reused-buffer (toggle-truncate-lines 1)))

--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -1,4 +1,4 @@
-;;; live-py-mode.el --- Live Coding in Python
+;;; live-py-mode.el --- Live Coding in Python -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Don Kirkby
 
@@ -37,14 +37,15 @@
 (defvar live-py-lighter)
 
 (defun live-py-after-change-function (start stop len)
-  "Run the buffer through the code tracer and show results in the trace buffer."
+  "After a delay run the buffer through the code tracer and show trace.
+START, STOP and LEN are required by `after-change-functions' but unused."
+  (ignore start stop len)
   (when live-py-timer (cancel-timer live-py-timer))
   (set 'live-py-timer (run-at-time 0.5 nil 'live-py-trace)))
 
 (defun live-py-trace ()
   "Trace the Python code using code_tracer.py."
   (let* ((tracer-path (locate-file "code_tracer.py" load-path))
-         (buffer-dir (file-name-directory (buffer-file-name)))
          (command-line-start (concat
 			      (shell-quote-argument live-py-version)
 			      " "
@@ -183,7 +184,8 @@ Typical values are 'python' or 'python3'."
                       nil
                       t)))
   (unless (string-prefix-p live-py-dir buffer-file-name)
-    (error "Working directory must be a parent of %s." buffer-file-name))
+    (user-error "Working directory must be a parent of %s"
+                buffer-file-name))
   (setq live-py-module (file-name-base buffer-file-name))
   (setq live-py-parent (directory-file-name
 			(file-name-directory buffer-file-name)))
@@ -223,7 +225,7 @@ With arg, turn mode on if and only if arg is positive.
 	    (define-key map (kbd "C-c M-v") 'live-py-set-version)
 	    map)
   (unless (buffer-file-name)
-    (error "Current buffer has no associated file!"))
+    (user-error "Current buffer has no associated file"))
   (cond
 
    ;; Turning the mode ON.

--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -50,6 +50,8 @@ START, STOP and LEN are required by `after-change-functions' but unused."
 
 (defun live-py-trace-update ()
   "Trace the Python code using code_tracer.py."
+  ;; For when called from elsewhere than `live-py-after-change-function'.
+  (when live-py-timer (cancel-timer live-py-timer))
   (setq-local live-py-lighter " Live-T") ; T for tracing
   (force-mode-line-update)
   (redisplay)
@@ -172,7 +174,7 @@ To use a unit test, set the driver to something like this:
 -m unittest mymodule.MyTest.test_method"
   (interactive)
   (setq live-py-driver (read-string "Type the driver command:"))
-  (live-py-after-change-function 0 0 0))
+  (live-py-trace-update))
 
 (defun live-py-set-version()
   "Prompt user to enter the python command, with input history support.
@@ -180,7 +182,7 @@ Typical values are 'python' or 'python3'."
   (interactive)
   (setq live-py-version (expand-file-name
                          (read-shell-command "Type the python command:")))
-  (live-py-after-change-function 0 0 0))
+  (live-py-trace-update))
 
 (defun live-py-set-dir()
   "Prompt user to enter the working directory."
@@ -205,7 +207,7 @@ Typical values are 'python' or 'python3'."
     (setq-local live-py-parent (directory-file-name
                                 (file-name-directory live-py-parent))))
   (setq live-py-dir (file-name-as-directory live-py-dir))
-  (live-py-after-change-function 0 0 0))
+  (live-py-trace-update))
 
 (defun live-py-set-path()
   "Prompt user to enter extra directories for the Python path."
@@ -253,7 +255,7 @@ With arg, turn mode on if and only if arg is positive.
     (add-hook 'kill-buffer-hook 'live-py-mode-off nil t)
     (add-hook 'after-change-functions 'live-py-after-change-function nil t)
     (live-py-show-output-window)
-    (live-py-after-change-function 0 0 0)
+    (live-py-trace-update)
     (add-hook 'post-command-hook 'live-py-check-to-scroll nil t))
    ;; Turning the mode OFF.
    (t


### PR DESCRIPTION
This is convenient to see what happens during edit and update when using or developing for the Emacs plugin. Test with something slow like `time.sleep(1.4)`.