### PR TITLE
Fix incorrect window start position

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -125,14 +125,7 @@ START, STOP and LEN are required by `after-change-functions' but unused."
                                           (1+ (buffer-size))
                                           command-line
                                           live-py-trace-name))
-           (progn
-             ;; Append empty lines to match source buffer line count
-             (let ((source-line-count (count-lines 1 (1+ (buffer-size)))))
-               (with-current-buffer live-py-trace-name
-                 (goto-char (point-max))
-                 (newline (- source-line-count (count-lines 1 (point-max))))))
-
-             live-py-lighter-ready)
+           live-py-lighter-ready
          live-py-lighter-fail))
       (force-mode-line-update)
       (redisplay))
@@ -157,13 +150,13 @@ aligned but will not hide the part after the narrowing."
          (window-start-line-nr (+ point-min-line-nr window-start-line-nr -1))
          (point-line-nr (+ point-min-line-nr point-line-nr -1)))
     (unless output-window
-      (live-py-create-output-window)
-      (set-window-buffer output-window live-py-trace-name))
+      (live-py-create-output-window))
     (with-selected-window output-window
       (goto-char 1)
       (forward-line window-start-line-nr)
       (recenter-top-bottom 0)
-      (forward-line (- point-line-nr window-start-line-nr)))))
+      (forward-line (- point-line-nr window-start-line-nr)))
+    (set-window-buffer output-window live-py-trace-name)))
 
 (defun live-py-post-command-function ()
   "Update window start and point of trace buffer if necessary."
@@ -172,7 +165,7 @@ aligned but will not hide the part after the narrowing."
   ;; interactivity when `debug-on-error' is active, so it is easily possible
   ;; to miss the error. And on such an error the function will be removed
   ;; from `post-command-hook' which is confusing when not noticed.
-  (when (memq this-command '(narrow-to-region next-line previous-line viper-goto-line))
+  (when (memq this-command '(narrow-to-region next-line viper-goto-line))
     ;; `window-start' is for some reason not up to date after
     ;; `post-command-hook' in at least these situations:
     ;; - For a few commands like `narrow-to-region' or `viper-goto-line'.

--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -125,7 +125,14 @@ START, STOP and LEN are required by `after-change-functions' but unused."
                                           (1+ (buffer-size))
                                           command-line
                                           live-py-trace-name))
-           live-py-lighter-ready
+           (progn
+             ;; Append empty lines to match source buffer line count
+             (let ((source-line-count (count-lines 1 (1+ (buffer-size)))))
+               (with-current-buffer live-py-trace-name
+                 (goto-char (point-max))
+                 (newline (- source-line-count (count-lines 1 (point-max))))))
+
+             live-py-lighter-ready)
          live-py-lighter-fail))
       (force-mode-line-update)
       (redisplay))

--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -147,6 +147,7 @@ When the source buffer is narrowed the trace buffer remains
 aligned but will not hide the part after the narrowing."
   (let* ((output-window (get-buffer-window live-py-trace-name))
          (point-min-pos (point-min))
+         (scroll-margin 0)
          (point-min-line-nr (if (= 1 point-min-pos)
                                 1
                               ;; Compensate for narrowing.

--- a/plugin/PySrc/code_tracer.py
+++ b/plugin/PySrc/code_tracer.py
@@ -943,7 +943,7 @@ class CodeTracer(object):
                     messages = traceback.format_exception_only(etype, value)
                 self.report_driver_result(builder, messages)
 
-        report = builder.report()
+        report = builder.report(source.count('\n'))
         if dump:
             source_lines = source.splitlines()
             report_lines = report.splitlines()

--- a/plugin/PySrc/report_builder.py
+++ b/plugin/PySrc/report_builder.py
@@ -190,7 +190,7 @@ class ReportBuilder(object):
     def record_delete(self, name, target, line_number):
         return DeletionTarget(name, target, line_number, self)
 
-    def report(self):
+    def report(self, total_lines):
         self.max_width = None
         for frame in self.history:
             first_line, last_line = frame.stack_block
@@ -201,6 +201,7 @@ class ReportBuilder(object):
                     line_number = i+1
                     self.add_message(message, line_number)
         self.history = []
+        self._check_line_count(total_lines)
         return '\n'.join(self.messages)
 
     def _check_line_count(self, line_count):


### PR DESCRIPTION
If the value of `scroll-margin` is not 0, the live buffer won't align with source code buffer properly.

Wasn't sure whether to compensate for `scroll-margin` manually, so decided to set it to 0 locally for sake of simplicity.