### PR TITLE
Switch out the use of os.linesep for \n

### DIFF
--- a/plugin/PySrc/report_builder.py
+++ b/plugin/PySrc/report_builder.py
@@ -117,8 +117,8 @@ class ReportBuilder(object):
         if self.current_output:
             if self.current_output_is_stderr:
                 template = 'sys.stderr.write({!r}) '
-            elif self.current_output.endswith(os.linesep):
-                self.current_output = self.current_output[:-len(os.linesep)]
+            elif self.current_output.endswith('\n'):
+                self.current_output = self.current_output[:-len('\n')]
                 template = 'print({!r}) ' if self.has_print_function else 'print {!r} '
             else:
                 template = 'sys.stdout.write({!r}) '

--- a/plugin/PySrc/report_builder.py
+++ b/plugin/PySrc/report_builder.py
@@ -118,7 +118,7 @@ class ReportBuilder(object):
             if self.current_output_is_stderr:
                 template = 'sys.stderr.write({!r}) '
             elif self.current_output.endswith('\n'):
-                self.current_output = self.current_output[:-len('\n')]
+                self.current_output = self.current_output[:-1]
                 template = 'print({!r}) ' if self.has_print_function else 'print {!r} '
             else:
                 template = 'sys.stdout.write({!r}) '


### PR DESCRIPTION
This change is to fix a bug on Windows systems which showed the incorrect
output for a print statement.
In the live coding display,
    sys.stdout.write('a\n')
was shown instead of the expected
    print('a')

The fix is based on the idea that the print function's default end of line
character is \n, a newline, and not the Windows \r\n, carridge return and
newline.