### PR TITLE
Add pass only methods for screen.tracer and screen.update

### DIFF
--- a/plugin/PySrc/mock_turtle.py
+++ b/plugin/PySrc/mock_turtle.py
@@ -45,6 +45,12 @@ class MockTurtle(TNavigator, TPen):
                 return bgcolor
             self._config['bgcolor'] = color
 
+        def tracer(self, a=None, b=None):
+            pass
+
+        def update(self):
+            pass
+
     _Stamp = namedtuple('Stamp', 'pos heading color')
     _screen = _pen = OriginalTurtle = original_mainloop = None
     instances = []

--- a/test/PySrc/tests/test_mock_turtle.py
+++ b/test/PySrc/tests/test_mock_turtle.py
@@ -743,10 +743,10 @@ create_line
 
     def test_screen_methods_exist(self):
         # SETUP
-        screen_methods = ['tracer', 'update']
         t = MockTurtle()
 
         # EXEC
 
         # VERIFY
-        self.assertTrue(all([hasattr(t.screen, attribute) for attribute in screen_methods]))
+        t.screen.tracer()
+        t.screen.update()

--- a/test/PySrc/tests/test_mock_turtle.py
+++ b/test/PySrc/tests/test_mock_turtle.py
@@ -740,3 +740,13 @@ create_line
 
         # VERIFY
         self.assertFalse(hasattr(t, 'bogus'))
+
+    def test_screen_methods_exist(self):
+        # SETUP
+        screen_methods = ['tracer', 'update']
+        t = MockTurtle()
+
+        # EXEC
+
+        # VERIFY
+        self.assertTrue(all([hasattr(t.screen, attribute) for attribute in screen_methods]))


### PR DESCRIPTION
Fixes #167
The Turtle Screen object has the methods tracer and update to draw the
turtle immediately on screen instead of being animated.
This does not work with the live turtle visualization created by this project.
But these two methods are something a typical turtle user could use in a script,
so they should be handled without error if called in a script.

I've added the two method as pass only methods to prevent an error, and I've
added a test verifying the tracer and update attributes exist.
Surprisingly, the pass only methods seem to be enough to satisfy the rest of the
testing suite.