### PR TITLE
Fix issue with bad encoding on windows

### DIFF
--- a/emacs-live-py-mode/live-py-mode.el
+++ b/emacs-live-py-mode/live-py-mode.el
@@ -354,7 +354,6 @@ With arg, turn mode on if and only if arg is positive.
 (provide 'live-py-mode)
 
 ;; Local Variables:
-;;   coding: us-ascii-unix
 ;;   fill-column: 76
 ;;   indent-tabs-mode: nil
 ;; End:


### PR DESCRIPTION
By forcing the encoding to a unix variant, Emacs does not correctly handle windows style line endings. This prevents the code from being compiled. Let Emacs handle the encoding automatically, which it is designed to do.