### PR TITLE
Switched to HTML <progress> in browser

### DIFF
--- a/html/src/App.css
+++ b/html/src/App.css
@@ -65,20 +65,32 @@ progress[value]::-webkit-progress-bar {
   border-radius: 9999px;
 }
 
-progress[value]::-webkit-progress-value {
+progress[type="danger"]::-webkit-progress-value {
   border-radius: 9999px;
-  background-image:
-    -webkit-linear-gradient(left, 
-      hsl(348, 86%, 61%), 
-      hsl(44,  100%, 77%),
-      hsl(153, 53%,  53%));
+  background: hsl(348, 86%, 61%);
 }
 
-progress[value]::-moz-progress-bar {
+progress[type="warning"]::-webkit-progress-value {
   border-radius: 9999px;
-  background-image:
-	   -moz-linear-gradient(left, 
-      hsl(348, 86%, 61%), 
-      hsl(44,  100%, 77%),
-      hsl(153, 53%,  53%));
+  background: hsl(44, 100%, 77%);
+}
+
+progress[type="success"]::-webkit-progress-value {
+  border-radius: 9999px;
+  background: hsl(153, 53%, 53%);
+}
+
+progress[type="danger"]::-moz-progress-bar {
+  border-radius: 9999px;
+  background: hsl(348, 86%, 61%);
+}
+
+progress[type="warning"]::-moz-progress-bar {
+  border-radius: 9999px;
+  background: hsl(44, 100%, 77%);
+}
+
+progress[type="success"]::-moz-progress-bar {
+  border-radius: 9999px;
+  background: hsl(153, 53%, 53%);
 }

--- a/html/src/App.css
+++ b/html/src/App.css
@@ -56,6 +56,8 @@ progress[value] {
   -moz-appearance: none;
   appearance: none;
   
+  height: 2em;
+  width: 100%;
 }
 
 progress[value]::-webkit-progress-bar {

--- a/html/src/App.css
+++ b/html/src/App.css
@@ -40,26 +40,43 @@
 }
 
 .danger {
-  background: hsl(348, 100%, 61%);
+  color: hsl(348, 86%, 61%);
 }
 
 .warning {
-  background: hsl(48, 100%, 67%);
+  color: hsl(44,  100%, 77%);
 }
 
 .success {
-  background: hsl(141, 53%, 53%);
+  color: hsl(153, 53%,  53%);
 }
 
-.progressbar-wrapper {
-  height: 2em;
-  width: 100%;
-  border-radius: 5px;
-  border: 2px solid #212121;
+progress[value] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  
 }
 
-.progressbar-filler {
-  height: 100%;
-  border-radius: inherit;
-  transition: width .2s ease-in;
+progress[value]::-webkit-progress-bar {
+  background-color: hsl(0, 0%, 93%);
+  border-radius: 9999px;
+}
+
+progress[value]::-webkit-progress-value {
+  border-radius: 9999px;
+  background-image:
+    -webkit-linear-gradient(left, 
+      hsl(348, 86%, 61%), 
+      hsl(44,  100%, 77%),
+      hsl(153, 53%,  53%));
+}
+
+progress[value]::-moz-progress-bar {
+  border-radius: 9999px;
+  background-image:
+	   -moz-linear-gradient(left, 
+      hsl(348, 86%, 61%), 
+      hsl(44,  100%, 77%),
+      hsl(153, 53%,  53%));
 }

--- a/html/src/App.js
+++ b/html/src/App.js
@@ -96,10 +96,7 @@ class ProgressBar extends Component {
             (this.props.percentage < 100) ?
                 "warning" :
                 "success";
-        return <div className="progressbar-wrapper ">
-            <div className={"progressbar-filler " + stateClass}
-                 style={{width: `${this.props.percentage}%`}}/>
-        </div>;
+        return <progress className={stateClass} value={`${this.props.percentage}`} max="100"/>;
     }
 }
 

--- a/html/src/App.js
+++ b/html/src/App.js
@@ -96,7 +96,7 @@ class ProgressBar extends Component {
             (this.props.percentage < 100) ?
                 "warning" :
                 "success";
-        return <progress className={stateClass} value={`${this.props.percentage}`} max="100"/>;
+        return <progress className={stateClass} type={stateclass} value={`${this.props.percentage}`} max="100"/>;
     }
 }
 

--- a/html/src/App.js
+++ b/html/src/App.js
@@ -96,7 +96,7 @@ class ProgressBar extends Component {
             (this.props.percentage < 100) ?
                 "warning" :
                 "success";
-        return <progress className={stateClass} type={stateclass} value={`${this.props.percentage}`} max="100"/>;
+        return <progress className={stateClass} type={stateClass} value={`${this.props.percentage}`} max="100"/>;
     }
 }
 


### PR DESCRIPTION
#419 

Switched to HTML native <progress> bar.

The css uses the [value] attribute, to have a solid color for specific values of the progress bar, multiple css entries must be made for progress[value="x"]. That would need 100 css values for the original progress bar implementation. So mine uses a gradient of danger, warning, and success. Colors and border radius follow the [Bulma ](https://bulma.io/documentation/elements/progress/#variables) scheme.

IE 10+ supports progress bar partially. It only allows changing the color of the progress bar value with the color attribute.